### PR TITLE
Use pytest for faster test runs

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -21,8 +21,7 @@ def keep_item(item):
         # The class belongs to the module it was found in.
         return True
     else:
-        # FIXME: Report this better.
-        print "Skipping test from bad module:", item.nodeid
+        return False
 
 
 def pytest_collection_modifyitems(session, config, items):
@@ -30,8 +29,14 @@ def pytest_collection_modifyitems(session, config, items):
     Filter out all tests collected from TestCase classes that weren't defined
     in the module they were found in.
     """
-    new_items = []
+    deselected = []
+    remaining = []
     for item in items:
         if keep_item(item):
-            new_items.append(item)
-    items[:] = new_items
+            remaining.append(item)
+        else:
+            deselected.append(item)
+
+    if deselected:
+        config.hook.pytest_deselected(items=deselected)
+        items[:] = remaining

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,37 @@
+from _pytest.python import Module
+from _pytest.unittest import TestCaseFunction, UnitTestCase
+
+
+def keep_item(item):
+    """
+    Return `False` for tests collected from TestCase classes that weren't
+    defined in the module they were found in, `True` otherwise.
+    """
+    if not isinstance(item, TestCaseFunction):
+        # This isn't a TestCase method, so keep it.
+        return True
+
+    parent_cls = item.getparent(UnitTestCase)
+    parent_module = item.getparent(Module)
+    if None in (parent_cls, parent_module):
+        # Should this be possible? We can't filter, though, so keep it.
+        return True
+
+    if parent_cls.cls.__module__ == parent_module.module.__name__:
+        # The class belongs to the module it was found in.
+        return True
+    else:
+        # FIXME: Report this better.
+        print "Skipping test from bad module:", item.nodeid
+
+
+def pytest_collection_modifyitems(session, config, items):
+    """
+    Filter out all tests collected from TestCase classes that weren't defined
+    in the module they were found in.
+    """
+    new_items = []
+    for item in items:
+        if keep_item(item):
+            new_items.append(item)
+    items[:] = new_items

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+python_files=*test*.py
+DJANGO_SETTINGS_MODULE = temba.settings
+addopts = --reuse-db

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -4,7 +4,7 @@ from hamlpy import templatize
 #-----------------------------------------------------------------------------------
 # Sets TESTING to True if this configuration is read during a unit test
 #-----------------------------------------------------------------------------------
-TESTING = sys.argv[1:2] == ['test']
+TESTING = (sys.argv[1:2] == ['test']) or ('py.test' in sys.argv[0])
 
 #-----------------------------------------------------------------------------------
 # Default to debugging


### PR DESCRIPTION
`py.test` allows us to reuse the test database across runs (thus avoiding lengthly setup and migration) and has some other features (flexible test selection, rerunning failed tests) that are useful for local development.